### PR TITLE
Add omitempty to LbSnatTranslation ipAddresses

### DIFF
--- a/loadbalancer/lb_snat_translation.go
+++ b/loadbalancer/lb_snat_translation.go
@@ -18,5 +18,5 @@ type LbSnatTranslation struct {
 	Type_ string `json:"type"`
 
         // Currently, only one single IP address or IP range is supported. If an IP range is specified, the range may contain no more than 64 IP addresses.
-	IpAddresses []LbSnatIpElement `json:"ip_addresses"`
+	IpAddresses []LbSnatIpElement `json:"ip_addresses,omitempty"`
 }


### PR DESCRIPTION
This attribute is only recognized by some of the types, and should
be omited for the others.

Signed-off-by: Adit Sarfaty <asarfaty@vmware.com>