### PR TITLE
Change bool to *bool in superset type

### DIFF
--- a/loadbalancer/lb_rule_condition.go
+++ b/loadbalancer/lb_rule_condition.go
@@ -31,7 +31,7 @@ type LbRuleCondition struct {
 	Method string `json:"method,omitempty"`
 
 	// If true, case is significant
-	CaseSensitive bool `json:"case_sensitive,omitempty"`
+	CaseSensitive *bool `json:"case_sensitive,omitempty"`
 
 	// Match type
 	MatchType string `json:"match_type,omitempty"`


### PR DESCRIPTION
LbRuleCondition needs to support omitempty bool, since its a
superset type for different rule condition types.
In order to distinguish between false value and unset value for the
omitempty bool, we need to change it to *bool