### PR TITLE
Add API to read load balancer service status

### DIFF
--- a/loadbalancer/lb_pool_member_status.go
+++ b/loadbalancer/lb_pool_member_status.go
@@ -1,0 +1,20 @@
+package loadbalancer
+
+type LbPoolMemberStatus struct {
+
+	// The healthcheck failure cause when status is DOWN
+	FailureCause string `json:"failure_cause,omitempty"`
+
+	// Pool member status
+	IPAddress string `json:"ip_address"`
+
+	LastCheckTime int64 `json:"last_check_time,omitempty"`
+
+	LastStateChangeTime int64 `json:"last_state_change_time,omitempty"`
+
+	// Pool member port
+	Port string `json:"port,omitempty"`
+
+	// Pool member status
+	Status string `json:"status"`
+}

--- a/loadbalancer/lb_pool_status.go
+++ b/loadbalancer/lb_pool_status.go
@@ -1,0 +1,16 @@
+package loadbalancer
+
+type LbPoolStatus struct {
+
+	// Timestamp when the data was last updated
+	LastUpdateTimestamp int64 `json:"last_update_timestamp,omitempty"`
+
+	// Status of load balancer pool members
+	Members []LbPoolMemberStatus `json:"members,omitempty"`
+
+	// Load balancer pool identifier
+	PoolId string `json:"pool_id"`
+
+	// Virtual server status
+	Status string `json:"status"`
+}

--- a/loadbalancer/lb_service_status.go
+++ b/loadbalancer/lb_service_status.go
@@ -1,0 +1,34 @@
+package loadbalancer
+
+type LbServiceStatus struct {
+
+	// Ids of load balancer service related active transport nodes
+	ActiveTransportNodes []string `json:"active_transport_nodes,omitempty"`
+
+	// Cpu usage in percentage
+	CPUUsage int64 `json:"cpu_usage"`
+
+	// Cpu usage in percentage
+	ErrorMessage string `json:"error_message,omitempty"`
+
+	// Timestamp when the data was last updated
+	LastUpdateTimestamp int64 `json:"last_update_timestamp,omitempty"`
+
+	// Memory usage in percentage
+	MemoryUsage int64 `json:"memory_usage"`
+
+	// status of load balancer pools
+	Pools []LbPoolStatus `json:"pools,omitempty"`
+
+	// Load balancer service identifier
+	ServiceId string `json:"service_id"`
+
+	// Status of load balancer service
+	ServiceStatus string `json:"service_status"`
+
+	// Ids of load balancer service related standby transport nodes
+	StandbyTransportNodes []string `json:"standby_transport_nodes,omitempty"`
+
+	// status of load balancer virtual servers
+	VirtualServers []LbVirtualServerStatus `json:"virtual_servers,omitempty"`
+}

--- a/loadbalancer/lb_virtual_server_status.go
+++ b/loadbalancer/lb_virtual_server_status.go
@@ -1,0 +1,13 @@
+package loadbalancer
+
+type LbVirtualServerStatus struct {
+
+	// Timestamp when the data was last updated.
+	LastUpdateTimestamp int64 `json:"last_update_timestamp,omitempty"`
+
+	// Virtual server status
+	Status string `json:"status"`
+
+	// load balancer virtual server identifier
+	VirtualServerId string `json:"virtual_server_id"`
+}

--- a/services_api.go
+++ b/services_api.go
@@ -8329,6 +8329,79 @@ func (a *ServicesApiService) ReadLoadBalancerService(ctx context.Context, servic
 	return successPayload, localVarHttpResponse, err
 }
 
+/* ServicesApiService Retrieve a status of load balancer service.
+Retrieve a status of load balancer service.
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param serviceId
+@param optional (nil or map[string]interface{}) with one or more of:
+	@param "source" (string) Data source type.
+@return loadbalancer.LbServiceStatus*/
+func (a *ServicesApiService) ReadLoadBalancerServiceStatus(ctx context.Context, serviceId string, localVarOptionals map[string]interface{}) (loadbalancer.LbServiceStatus, *http.Response, error) {
+	var (
+		localVarHttpMethod = strings.ToUpper("Get")
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     loadbalancer.LbServiceStatus
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/loadbalancer/services/{service-id}/status"
+	localVarPath = strings.Replace(localVarPath, "{"+"service-id"+"}", fmt.Sprintf("%v", serviceId), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	if err := typeCheckParameter(localVarOptionals["source"], "string", "source"); err != nil {
+		return successPayload, nil, err
+	}
+
+	if localVarTempParam, localVarOk := localVarOptionals["source"].(string); localVarOk {
+		localVarQueryParams.Add("source", parameterToString(localVarTempParam, ""))
+	}
+
+	// to determine the Content-Type header
+	localVarHttpContentTypes := []string{"application/json"}
+
+	// set Content-Type header
+	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
+	if localVarHttpContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHttpContentType
+	}
+
+	// to determine the Accept header
+	localVarHttpHeaderAccepts := []string{
+		"application/json",
+	}
+
+	// set Accept header
+	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
+	if localVarHttpHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
+	}
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	if err != nil {
+		return successPayload, nil, err
+	}
+
+	localVarHttpResponse, err := a.client.callAPI(r)
+	if err != nil || localVarHttpResponse == nil {
+		return successPayload, localVarHttpResponse, err
+	}
+	defer localVarHttpResponse.Body.Close()
+	if localVarHttpResponse.StatusCode >= 300 {
+		bodyBytes, _ := ioutil.ReadAll(localVarHttpResponse.Body)
+		return successPayload, localVarHttpResponse, reportError("Status: %v, Body: %s", localVarHttpResponse.Status, bodyBytes)
+	}
+
+	if err = json.NewDecoder(localVarHttpResponse.Body).Decode(&successPayload); err != nil {
+		return successPayload, localVarHttpResponse, err
+	}
+
+	return successPayload, localVarHttpResponse, err
+}
+
 /* ServicesApiService Read the debug information of the load balancer service
 API to download below information which will be used for debugging and troubleshooting. 1) Load balancer service 2) Load balancer associated virtual servers 3) Load balancer associated pools 4) Load balancer associated profiles such as persistence, SSL, application. 5) Load balancer associated monitors 6) Load balancer associated rules
 * @param ctx context.Context for authentication, logging, tracing, etc.


### PR DESCRIPTION
This API will retrieve the status of the load balancer service. Several structs are created in order to support the full response object of this API.

Addresses: #22
Signed-off-by: William Albertus Dembo <w.albertusd@gmail.com>