### PR TITLE
Add API to read load balancer service statistics

### DIFF
--- a/loadbalancer/lb_pool_member_statistics.go
+++ b/loadbalancer/lb_pool_member_statistics.go
@@ -1,0 +1,12 @@
+package loadbalancer
+
+type LbPoolMemberStatistics struct {
+	// Pool member IP Address
+	IPAddress string `json:"ip_address"`
+
+	// Pool member port
+	Port string `json:"port,omitempty"`
+
+	// Pool member statistics counter
+	Statistics LbStatisticsCounter `json:"statistics"`
+}

--- a/loadbalancer/lb_pool_statistics.go
+++ b/loadbalancer/lb_pool_statistics.go
@@ -1,0 +1,15 @@
+package loadbalancer
+
+type LbPoolStatistics struct {
+	// Timestamp when the data was last updated
+	LastUpdateTimestamp int64 `json:"last_update_timestamp,omitempty"`
+
+	// Statistics of load balancer pool members
+	Members []LbPoolMemberStatistics `json:"members,omitempty"`
+
+	// Load balancer pool identifier
+	PoolId string `json:"pool_id"`
+
+	// Load balancer statistics counter
+	Statistics LbStatisticsCounter `json:"statistics"`
+}

--- a/loadbalancer/lb_service_statisitcs_counter.go
+++ b/loadbalancer/lb_service_statisitcs_counter.go
@@ -1,0 +1,27 @@
+package loadbalancer
+
+type LbServiceStatisticsCounter struct {
+	// Number of l4 current sessions
+	L4CurrentSessions int64 `json:"l4_current_sessions,omitempty"`
+
+	// The average number of l4 current sessions per second, the number is averaged over the last 5 one-second intervals.
+	L4CurrentSessionRate float64 `json:"l4_current_session_rate,omitempty"`
+
+	// Number of l4 maximum sessions
+	L4MaxSessions int64 `json:"l4_max_sessions,omitempty"`
+
+	// Number of l4 total sessions
+	L4TotalSessions int64 `json:"l4_total_sessions,omitempty"`
+
+	// Number of l7 current sessions
+	L7CurrentSessions int64 `json:"l7_current_sessions,omitempty"`
+
+	// The average number of l7 current sessions per second, the number is averaged over the last 5 one-second intervals.
+	L7CurrentSessionRate float64 `json:"l7_current_session_rate,omitempty"`
+
+	// Number of l7 maximum sessions
+	L7MaxSessions int64 `json:"l7_max_sessions,omitempty"`
+
+	// Number of l7 total sessions
+	L7TotalSessions int64 `json:"l7_total_sessions,omitempty"`
+}

--- a/loadbalancer/lb_service_statistics.go
+++ b/loadbalancer/lb_service_statistics.go
@@ -1,0 +1,18 @@
+package loadbalancer
+
+type LbServiceStatistics struct {
+	// Timestamp when the data was last updated
+	LastUpdateTimestamp int64 `json:"last_update_timestamp,omitempty"`
+
+	// Statistics of load balancer pools
+	Pools []LbPoolStatistics `json:"pools,omitempty"`
+
+	// Load balancer service identifier
+	ServiceId string `json:"service_id"`
+
+	// Load balancer service statistics counter
+	Statistics LbServiceStatisticsCounter `json:"statistics,omitempty"`
+
+	// Statistics of load balancer virtual servers
+	VirtualServes []LbVirtualServerStatistics `json:"virtual_servers,omitempty"`
+}

--- a/loadbalancer/lb_statistics_counter.go
+++ b/loadbalancer/lb_statistics_counter.go
@@ -1,0 +1,48 @@
+package loadbalancer
+
+type LbStatisticsCounter struct {
+	// Number of bytes in
+	BytesIn int64 `json:"bytes_in"`
+
+	// The average number of inbound bytes per second, the number is averaged over the last 5 one-second intervals.
+	BytesInRate float64 `json:"bytes_in_rate,omitempty"`
+
+	// Number of bytes out
+	BytesOut int64 `json:"bytes_out"`
+
+	// The average number of outbound bytes per second, the number is averaged over the last 5 one-second intervals.
+	BytesOutRate float64 `json:"bytes_out_rate,omitempty"`
+
+	// Number of current sessions
+	CurrentSessions int64 `json:"current_sessions"`
+
+	// The average number of current sessions per second, the number is averaged over the last 5 one-second intervals.
+	CurrentSessionRate float64 `json:"current_session_rate,omitempty"`
+
+	// Number of http requests
+	HttpRequests int64 `json:"http_requests"`
+
+	// The average number of http requests per second, the number is averaged over the last 5 one-second intervals.
+	HttpRequestRate float64 `json:"http_request_rate,omitempty"`
+
+	// Number of maximum sessions
+	MaxSessions int64 `json:"max_sessions"`
+
+	// Number of packets in
+	PacketsIn int64 `json:"packets_in,omitempty"`
+
+	// The average number of inbound packets per second, the number is averaged over the last 5 one-second intervals.
+	PacketsInRate float64 `json:"packets_in_rate,omitempty"`
+
+	// Number of packets out
+	PacketsOut int64 `json:"packets_out,omitempty"`
+
+	// The average number of outbound packets per second, the number is averaged over the last 5 one-second intervals.
+	PacketsOutRate float64 `json:"packets_out_rate,omitempty"`
+
+	// Number of source IP persistence entries
+	SourceIPPersistenceEntrySize int64 `json:"source_ip_persistence_entry_size,omitempty"`
+
+	// Number of total sessions
+	TotalSessions int64 `json:"total_sessions"`
+}

--- a/loadbalancer/lb_virtual_server_statistics.go
+++ b/loadbalancer/lb_virtual_server_statistics.go
@@ -1,0 +1,12 @@
+package loadbalancer
+
+type LbVirtualServerStatistics struct {
+	// Timestamp when the data was last updated
+	LastUpdateTimestamp int64 `json:"last_update_timestamp,omitempty"`
+
+	// Load balancer virtual server identifier
+	VirtualServerId string `json:"pool_id"`
+
+	// Virtual server statistics counter
+	Statistics LbStatisticsCounter `json:"statistics"`
+}

--- a/services_api.go
+++ b/services_api.go
@@ -8402,6 +8402,79 @@ func (a *ServicesApiService) ReadLoadBalancerServiceStatus(ctx context.Context, 
 	return successPayload, localVarHttpResponse, err
 }
 
+/* ServicesApiService Retrieve a statistics of load balancer service.
+Retrieve the statistics of load balancer service.
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param serviceId
+@param optional (nil or map[string]interface{}) with one or more of:
+	@param "source" (string) Data source type.
+@return loadbalancer.LbServiceStatistics*/
+func (a *ServicesApiService) ReadLoadBalancerServiceStatistics(ctx context.Context, serviceId string, localVarOptionals map[string]interface{}) (loadbalancer.LbServiceStatistics, *http.Response, error) {
+	var (
+		localVarHttpMethod = strings.ToUpper("Get")
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     loadbalancer.LbServiceStatistics
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/loadbalancer/services/{service-id}/statistics"
+	localVarPath = strings.Replace(localVarPath, "{"+"service-id"+"}", fmt.Sprintf("%v", serviceId), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	if err := typeCheckParameter(localVarOptionals["source"], "string", "source"); err != nil {
+		return successPayload, nil, err
+	}
+
+	if localVarTempParam, localVarOk := localVarOptionals["source"].(string); localVarOk {
+		localVarQueryParams.Add("source", parameterToString(localVarTempParam, ""))
+	}
+
+	// to determine the Content-Type header
+	localVarHttpContentTypes := []string{"application/json"}
+
+	// set Content-Type header
+	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
+	if localVarHttpContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHttpContentType
+	}
+
+	// to determine the Accept header
+	localVarHttpHeaderAccepts := []string{
+		"application/json",
+	}
+
+	// set Accept header
+	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
+	if localVarHttpHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
+	}
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	if err != nil {
+		return successPayload, nil, err
+	}
+
+	localVarHttpResponse, err := a.client.callAPI(r)
+	if err != nil || localVarHttpResponse == nil {
+		return successPayload, localVarHttpResponse, err
+	}
+	defer localVarHttpResponse.Body.Close()
+	if localVarHttpResponse.StatusCode >= 300 {
+		bodyBytes, _ := ioutil.ReadAll(localVarHttpResponse.Body)
+		return successPayload, localVarHttpResponse, reportError("Status: %v, Body: %s", localVarHttpResponse.Status, bodyBytes)
+	}
+
+	if err = json.NewDecoder(localVarHttpResponse.Body).Decode(&successPayload); err != nil {
+		return successPayload, localVarHttpResponse, err
+	}
+
+	return successPayload, localVarHttpResponse, err
+}
+
 /* ServicesApiService Read the debug information of the load balancer service
 API to download below information which will be used for debugging and troubleshooting. 1) Load balancer service 2) Load balancer associated virtual servers 3) Load balancer associated pools 4) Load balancer associated profiles such as persistence, SSL, application. 5) Load balancer associated monitors 6) Load balancer associated rules
 * @param ctx context.Context for authentication, logging, tracing, etc.


### PR DESCRIPTION
This API will retrieve the statistics of the load balancer service.
Several structs are created in order to support the full response object of this API.

Address #22 
Signed-off-by: William Albertus Dembo <w.albertusd@gmail.com>
