### PR TITLE
Add the vif_type in the context of logical port's attachemnt

### DIFF
--- a/manager/attachment_context.go
+++ b/manager/attachment_context.go
@@ -12,4 +12,7 @@ type AttachmentContext struct {
 
 	// Used to identify which concrete class it is
 	ResourceType string `json:"resource_type"`
+
+	// Used to indicate what the port is created for
+	VifType string `json:"vif_type,omitempty"`
 }


### PR DESCRIPTION
Otherwise the NSX will report the error "required property
attachment.context.vif_type is missing" when updating the
port with parent vif.