### PR TITLE
Allow passing certs as string rather than files

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -43,6 +43,9 @@ type Configuration struct {
 	ClientAuthCertFile   string
 	ClientAuthKeyFile    string
 	CAFile               string
+	ClientAuthCertString string
+	ClientAuthKeyString  string
+	CAString             string
 	Insecure             bool
 	RetriesConfiguration ClientRetriesConfiguration
 	HTTPClient           *http.Client


### PR DESCRIPTION
In containerised environments it is preferrable to path certificate
as string rather than create a file in file system. This change
exposes new configuration settings for this option.