### PR TITLE
Update container inventory objects

### DIFF
--- a/containerinventory/container_cluster.go
+++ b/containerinventory/container_cluster.go
@@ -33,6 +33,8 @@ type ContainerCluster struct {
 	Tags []common.Tag `json:"tags,omitempty"`
 	// Type of the container cluster. In case of creating container cluster first time, it is expected to pass the valid cluster-type. In case of update, if there is no change in cluster-type, then this field can be omitted in the request. 
 	ClusterType string `json:"cluster_type,omitempty"`
+	// Specifies Container Network Interface type for container cluster.
+	CniType string `json:"cni_type,omitempty"`
 	// External identifier of the container cluster.
 	ExternalId string `json:"external_id,omitempty"`
 	// Details of underlying infrastructure that hosts the container cluster. In case of creating container cluster first time, it is expected to pass the valid infrastructure. In case of update, if there is no change in cluster-type, then this field can be omitted in the request. 
@@ -43,4 +45,6 @@ type ContainerCluster struct {
 	NetworkStatus string `json:"network_status,omitempty"`
 	// Array of additional specific properties of container cluster in key-value format. 
 	OriginProperties []common.KeyValuePair `json:"origin_properties,omitempty"`
+	// Specifies supervisor container project identifier for cluster.
+	SupervisorProjectId string `json:"supervisor_project_id,omitempty"`
 }

--- a/containerinventory/container_cluster_node.go
+++ b/containerinventory/container_cluster_node.go
@@ -31,6 +31,8 @@ type ContainerClusterNode struct {
 	ResourceType string `json:"resource_type"`
 	// Opaque identifiers meaningful to the API user
 	Tags []common.Tag `json:"tags,omitempty"`
+	// Specifies Container Network Interface agent status of container cluster node.
+	CniAgentStatus string `json:"cni_agent_status,omitempty"`
 	// External identifier of the container cluster.
 	ContainerClusterId string `json:"container_cluster_id,omitempty"`
 	// External identifier of the container cluster node in K8S/PAS. 
@@ -43,4 +45,6 @@ type ContainerClusterNode struct {
 	NetworkStatus string `json:"network_status,omitempty"`
 	// Array of additional specific properties of container cluster node in key-value format. 
 	OriginProperties []common.KeyValuePair `json:"origin_properties,omitempty"`
+	// Specifies identifier of container cluster node given by infrastructure provider of container cluster. e.g. in case of vSpehere, it will be instance uuid of worker node virtual machine.
+	ProviderId string `json:"provider_id,omitempty"`
 }


### PR DESCRIPTION
This change updates container inventory objects based on latest APIs.
1. Add new field “cni_type” in ContainerCluster object.
2. Add new field “supervisor_project_id” in ContainerCluster object.
3. Add new field “provider_id” in CcntainerClusterNode object.
4. Add new field “cni_agent_status” in ContainerClusterNode object.

Signed-off-by: songm <songm@vmware.com>